### PR TITLE
Add support for unverified SSL connections

### DIFF
--- a/lib/puppet/provider/remote_file/ruby.rb
+++ b/lib/puppet/provider/remote_file/ruby.rb
@@ -33,6 +33,9 @@ Puppet::Type.type(:remote_file).provide(:ruby, :parent => Puppet::Provider::Remo
     end
     c = Net::HTTP.new(p.host, p.port)
     c.use_ssl = p.scheme == "https" ? true : false
+    if c.use_ssl? and @resource[:verify_peer] == false
+      c.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
     c.request_get(p.request_uri) do |req|
       case req.code
       when /30[12]/

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -33,4 +33,23 @@ Puppet::Type.newtype(:remote_file) do
       end
     end
   end
+
+  newparam(:verify_peer) do
+    desc "Whether or not to require verification of the the remote server identity"
+    validate do |value|
+      unless (value =~ /true|false/i or [true, false].include?(value))
+        raise ArgumentError.new("#{value} is not a boolean, should be either true or false")
+      end
+    end
+    munge do |value|
+      case value
+      when /true/i
+        true
+      when /false/i
+        false
+      else
+        value
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometimes it is required to download a file using SSL from a server using a self-signed or otherwise unverifiable SSL certificate. This commit introduces a new parameter, :verify_peer, which accepts a boolean true/false argument which when set to true allows download from an unverified peer.
