### PR TITLE
Add a default (present) to the ensure property

### DIFF
--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -1,7 +1,10 @@
 require 'uri'
 
 Puppet::Type.newtype(:remote_file) do
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "File path"


### PR DESCRIPTION
This allows the resource to be used without explicitly specifying ensure. I expect that in 90% of use cases ensure=present is what is intended, so this potentially saves a few characters or lines.
