### PR TITLE
Fix missed name=>path parameter rename symbols

### DIFF
--- a/lib/puppet/provider/remote_file.rb
+++ b/lib/puppet/provider/remote_file.rb
@@ -2,13 +2,13 @@ require 'digest/md5'
 
 class Puppet::Provider::Remote_file < Puppet::Provider
   def destroy
-    File.unlink @resource[:name]
+    File.unlink @resource[:path]
   end
 
   def exists?
-    if File.file? @resource[:name]
+    if File.file? @resource[:path]
       if cs = @resource[:checksum]
-        Digest::MD5.file(@resource[:name]) == cs
+        Digest::MD5.file(@resource[:path]) == cs
       else
         true
       end


### PR DESCRIPTION
When the name parameter was renamed path (which became the namevar) in #5, these explicit references to the parameter were missed. This commit changes the :name references to :path. This is necessary to prevent inconsistent behavior when using ensure=absent, or possibly when specifying both name and path simultaneously.
