### PR TITLE
Add support for basic auth

### DIFF
--- a/lib/puppet/provider/remote_file/ruby.rb
+++ b/lib/puppet/provider/remote_file/ruby.rb
@@ -168,6 +168,10 @@ Puppet::Type.type(:remote_file).provide(:ruby, :parent => Puppet::Provider::Remo
       options[:headers].each {|key,value| request[key] = value }
     end
 
+    if @resource[:username]
+      request.basic_auth(@resource[:username], @resource[:password])
+    end
+
     # Connect and perform the request
     http_method = connection.method("request_#{verb.downcase}".to_sym)
     recursive_response = nil

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -101,4 +101,20 @@ Puppet::Type.newtype(:remote_file) do
       end
     end
   end
+
+  newparam(:username) do
+    desc "Basic authentication username"
+  end
+
+  newparam(:password) do
+    desc "Basic authentication password"
+  end
+
+  validate do
+    # :username and :password must be specified together. It is an error to
+    # specify one but not the other. If only one is specified, fail validation.
+    if !parameters[:username].nil? ^ !parameters[:password].nil?
+      fail "username and password must both be specified if either is specified"
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a username and password parameter to the type and a basic_auth implementation in the provider for http, to allow specifying remote sources that require it.
