### PR TITLE
Add support for specifying a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,39 @@ remote_file { 'jenkins.war':
 }
 ```
 
+### Using a Proxy
+
+The `remote_file` type provides several proxy-related parameters. You should
+choose between specifying `proxy` or specifying `proxy_host` and `proxy_port`.
+The following two examples are equivalent.
+
+Using the `proxy` parameter:
+
+```puppet
+remote_file { '/path/to/your/file':
+  ensure   => present,
+  source   => 'http://example.com/file.tar.gz',
+  checksum => 'd41d8cd98f00b204e9800998ecf8427e'
+  proxy    => 'http://192.168.12.40:3128',
+}
+```
+
+Using `proxy_host` and `proxy_port` instead:
+
+```puppet
+remote_file { '/path/to/your/file':
+  ensure     => present,
+  source     => 'http://example.com/file.tar.gz',
+  checksum   => 'd41d8cd98f00b204e9800998ecf8427e'
+  proxy_host => '192.168.12.40',
+  proxy_port => 3128,
+}
+```
+
+If a username and/or password are required to authenticate to your proxy, you
+can specify these either as part of the `proxy` URI, or separately using the
+`proxy_username` and `proxy_password` parameters.
+
 ## Reference
 
 ### Type: remote_file
@@ -97,8 +130,12 @@ remote_file { 'jenkins.war':
   remote server identity.
 * `username`: Username to use for basic authentication.
 * `password`: Password to use for basic authentication.
-* `proxy_host`: The host name of an http/https proxy to use.
-* `proxy_port`: If using a proxy, the port to use to connect to the proxy.
+* `proxy`: The full URI of an http/https proxy to use, as it would be specified
+  in an environment variable; e.g. `http://myproxy.local:3128`.
+* `proxy_host`: The host name of an http/https proxy to use. Not required if
+  the `proxy` parameter is used.
+* `proxy_port`: If using a proxy, the port to use to connect to the proxy. Not
+  required if the `proxy` parameter is used.
 * `proxy_username`: If using a proxy, the username to use to authenticate to
   the proxy.
 * `proxy_password`: If using a proxy, the password to use to authenticate to

--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ remote_file { 'jenkins.war':
   remote server identity.
 * `username`: Username to use for basic authentication.
 * `password`: Password to use for basic authentication.
-
+* `proxy_host`: The host name of an http/https proxy to use.
+* `proxy_port`: If using a proxy, the port to use to connect to the proxy.
+* `proxy_username`: If using a proxy, the username to use to authenticate to
+  the proxy.
+* `proxy_password`: If using a proxy, the password to use to authenticate to
+  the proxy.
 
 ### Provider: ruby
 

--- a/lib/puppet/provider/remote_file/ruby.rb
+++ b/lib/puppet/provider/remote_file/ruby.rb
@@ -162,8 +162,15 @@ Puppet::Type.type(:remote_file).provide(:ruby, :parent => Puppet::Provider::Remo
     raise ArgumentError, 'HTTP redirect too deep' if limit == 0
 
     # Create the Net::HTTP connection and  request objects
-    connection = Net::HTTP.new(uri.host, uri.port)
     request    = REQUEST_TYPES[verb.to_s.downcase].new(uri.request_uri)
+    connection = Net::HTTP.new(
+      uri.host,
+      uri.port,
+      @resource[:proxy_host] || nil,
+      @resource[:proxy_port] || nil,
+      @resource[:proxy_username] || nil,
+      @resource[:proxy_password] || nil
+    )
 
     # Configure the Net::HTTP connection object
     if uri.scheme == 'https'

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -110,21 +110,66 @@ Puppet::Type.newtype(:remote_file) do
     desc "Basic authentication password"
   end
 
+  newparam(:proxy) do
+    desc "HTTP(S) Proxy URI. Example: http://192.168.12.40:3218"
+
+    validate do |url|
+      URI.parse(url).kind_of?(URI::HTTP)
+    end
+
+    munge do |url|
+      URI.parse(url)
+    end
+  end
+
   newparam(:proxy_host) do
-    desc "HTTP(S) Proxy host"
+    desc "HTTP(S) Proxy host. Do not use this if specifying the proxy parameter"
+
+    validate do |value|
+      if @resource[:proxy] && @resource[:proxy].host != value
+        raise "Conflict between proxy and proxy_host parameters."
+      end
+    end
+
+    defaultto { @resource[:proxy] ? @resource[:proxy].host : nil }
   end
 
   newparam(:proxy_port) do
-    desc "HTTP(S) Proxy port"
+    desc "HTTP(S) Proxy port. Do not use this if specifying the proxy parameter"
+
+    validate do |value|
+      if @resource[:proxy] && @resource[:proxy].port != value
+        raise "Conflict between proxy and proxy_port parameters."
+      end
+    end
+
+    defaultto { @resource[:proxy] ? @resource[:proxy].port : nil }
   end
 
   newparam(:proxy_username) do
     desc "HTTP(S) Proxy username"
+
+    validate do |value|
+      if @resource[:proxy] && @resource[:proxy].user != value
+        raise "Conflict between proxy and proxy_username parameters."
+      end
+    end
+
+    defaultto { @resource[:proxy] ? @resource[:proxy].user : nil }
   end
 
   newparam(:proxy_password) do
     desc "HTTP(S) Proxy password"
+
+    validate do |value|
+      if @resource[:proxy] && @resource[:proxy].password != value
+        raise "Conflict between proxy and proxy_password parameters."
+      end
+    end
+
+    defaultto { @resource[:proxy] ? @resource[:proxy].password : nil }
   end
+
 
   validate do
     # :username and :password must be specified together. It is an error to

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -110,11 +110,45 @@ Puppet::Type.newtype(:remote_file) do
     desc "Basic authentication password"
   end
 
+  newparam(:proxy_host) do
+    desc "HTTP(S) Proxy host"
+  end
+
+  newparam(:proxy_port) do
+    desc "HTTP(S) Proxy port"
+  end
+
+  newparam(:proxy_username) do
+    desc "HTTP(S) Proxy username"
+  end
+
+  newparam(:proxy_password) do
+    desc "HTTP(S) Proxy password"
+  end
+
   validate do
     # :username and :password must be specified together. It is an error to
     # specify one but not the other. If only one is specified, fail validation.
     if !parameters[:username].nil? ^ !parameters[:password].nil?
       fail "username and password must both be specified if either is specified"
+    end
+
+    # :proxy_host and :proxy_port must be specified together. It is an error to
+    # specify one but not the other. If only one is specified, fail validation.
+    if !parameters[:proxy_host].nil? ^ !parameters[:proxy_port].nil?
+      fail "proxy_host and proxy_port must both be specified if either is specified"
+    end
+
+    # :proxy_username and :proxy_password must be specified together. It is an error to
+    # specify one but not the other. If only one is specified, fail validation.
+    if !parameters[:proxy_username].nil? ^ !parameters[:proxy_password].nil?
+      fail "proxy_username and proxy_password must both be specified if either is specified"
+    end
+
+    # proxy_username/proxy_password should only be specified if
+    # proxy_host/proxy_port are.
+    if parameters[:proxy_host].nil? and !parameters[:proxy_username].nil?
+      fail "proxy_username and proxy_password may only be specified if proxy_host and proxy_port are also specified"
     end
   end
 end


### PR DESCRIPTION
This pull request adds five new parameters to the type.


For specifying a URI such as "https://username:password@192.168.12.40:3128":

* proxy

For specifying the same information as individual pieces:

* proxy_host
* proxy_port
* proxy_username
* proxy_password

These parameters enable downloading files from behind a proxy, if necessary.