### PR TITLE
Lint metadata.json to improve Forge quality score

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,11 +2,21 @@
   "name": "lwf-remote_file",
   "version": "0.2.3",
   "author": "lwf",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "summary": "A resource/provider for remote files.",
   "source": "https://github.com/lwf/puppet-remote_file",
   "project_page": "https://github.com/lwf/puppet-remote_file",
   "issues_url": "https://github.com/lwf/puppet-remote_file/issues",
   "tags": ["file", "remote", "http", "https"],
-  "dependencies": [ ]
+  "dependencies": [ ],
+  "operatingsystem_support": [
+    { "operatingsystem": "RedHat"  },
+    { "operatingsystem": "Windows" },
+    { "operatingsystem": "Debian"  },
+    { "operatingsystem": "Ubuntu"  },
+    { "operatingsystem": "OS X"    },
+    { "operatingsystem": "Solaris" },
+    { "operatingsystem": "SLES"    },
+    { "operatingsystem": "AIX"     }
+  ]
 }


### PR DESCRIPTION
In the metadata quality automatic score section on the Module Forge the previous metadata.json lost points on not indicating what operating systems were supported and because the license string was not recognized for Apache 2.0.

This commit adds OS support information (pretty much all OS's supported due to ruby net/http implementation) and modifies the license string "Apache License, Version 2.0" to the Forge-recognizable equivalent "Apache-2.0".

These changes should result in the module being given a metadata quality score of 5.0 (best).