### PR TITLE
Adding suport to set custom HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ can specify these either as part of the `proxy` URI, or separately using the
   the proxy.
 * `proxy_password`: If using a proxy, the password to use to authenticate to
   the proxy.
+* `headers`: Hash containing extra HTTP headers (can be
+  overriden by other conflicting parameters)
 
 ### Provider: ruby
 

--- a/lib/puppet/provider/remote_file/ruby.rb
+++ b/lib/puppet/provider/remote_file/ruby.rb
@@ -146,6 +146,10 @@ Puppet::Type.type(:remote_file).provide(:ruby, :parent => Puppet::Provider::Remo
 
     # Create the Net::HTTP connection and  request objects
     request    = REQUEST_TYPES[verb.to_s.downcase].new(uri.request_uri)
+    if @resource[:headers]
+      request.initialize_http_header(@resource[:headers])
+    end
+
     connection = Net::HTTP.new(
       uri.host,
       uri.port,
@@ -168,7 +172,7 @@ Puppet::Type.type(:remote_file).provide(:ruby, :parent => Puppet::Provider::Remo
     if options[:headers]
       options[:headers].each {|key,value| request[key] = value }
     end
-
+      
     if @resource[:username]
       request.basic_auth(@resource[:username], @resource[:password])
     end

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -182,6 +182,11 @@ Puppet::Type.newtype(:remote_file) do
     defaultto { @resource[:proxy] ? @resource[:proxy].password : nil }
   end
 
+  newparam(:headers) do
+    desc "HTTP(S) headers. Can be overwriten by others conflicting options"  
+    defaultto { {} }
+  end
+  
 
   validate do
     # checksum_type and checksum must be specified together


### PR DESCRIPTION
Hi! Sometimes, server could need some unconventional HTTP header for authentication. This pull request provides a way to send custom HTTP on requests.