### PR TITLE
Add owner, group, mode parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ can specify these either as part of the `proxy` URI, or separately using the
   the proxy.
 * `headers`: Hash containing extra HTTP headers (can be
   overriden by other conflicting parameters)
+* `owner`: owner attribute of the file. See the File type for details.
+* `group`: group attribute of the file. See the File type for details.
+* `mode`: mode attribute of the file. See the File type for details.
 
 ### Provider: ruby
 


### PR DESCRIPTION
Oftentimes it may be useful to declare the owner/group/mode of a
remote_file directly on the resource rather than separately declaring a
file resource. This commit adds those three parameters to the
remote_file type and uses the `generate()` api to automatically create
and contain a related file resource if those parameters are set.

The implementation goes out of its way to alert the user to situations
where they've both declared owner, group or mode parameters on a
remote_file resource and simultaneously declared a conflicting file
resource elsewhere in code. This makes the generate and eval_generate
methods a bit longer, but seems a desirable safeguard.