### PR TITLE
Add FTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ subsequent runs, so long as that file still exists, the resource will be
 considered in sync.
 
 The `remote_file` type supports tighter synchronization tolerances either
-through the specification of a checksum or by checking a remote HTTP
-server's Last-Modified header. For example, the following resource specifies a
-checksum:
+through the specification of a checksum, or by checking a remote HTTP server's
+Last-Modified header or using the FTP `MDTM` command. For example, the following
+resource specifies a checksum:
 
 ```puppet
 remote_file { '/path/to/your/file':
@@ -125,6 +125,8 @@ If a username and/or password are required to authenticate to your proxy, you
 can specify these either as part of the `proxy` URI, or separately using the
 `proxy_username` and `proxy_password` parameters.
 
+Note that `proxy` is not supported for files fetched using FTP.
+
 ## Reference
 
 ### Type: remote_file
@@ -137,7 +139,7 @@ can specify these either as part of the `proxy` URI, or separately using the
 * `source`: The source location of the file, or where to get it from if it is
   needed. This should be a URI.
 * `checksum`: Checksum of this file. Hash function used is specified by the `checksum_type`
-  parameter. A new copy of the file will not be downloaded if the local file's 
+  parameter. A new copy of the file will not be downloaded if the local file's
   checksum matches this value.
 * `checksum_type`: Hash algorithm to use for checksumming. Supports the same arguments
   as [the checksum parameter of the File type](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-checksum).
@@ -169,7 +171,7 @@ using Net::HTTP from Ruby's standard library.
 ## Limitations
 
 Currently only http, https, and file URI sources are supported by the default
-ruby provider. 
+ruby provider.
 
 ## License
 

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -79,7 +79,7 @@ Puppet::Type.newtype(:remote_file) do
   newparam(:source) do
     desc 'Location of the source file.'
     validate do |value|
-      unless value =~ URI.regexp(%w[http https file])
+      unless value =~ URI.regexp(%w[http https file ftp])
         raise ArgumentError, '%s is not a valid URL' % value
       end
     end

--- a/lib/puppet/type/remote_file.rb
+++ b/lib/puppet/type/remote_file.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:remote_file) do
 
     validate do |url|
       URI.parse(url).is_a?(URI::HTTP)
+
+      if @resource[:source] =~ /^ftp/
+        raise ArgumentError, "proxy cannot be used with FTP sources"
+      end
     end
 
     munge do |url|
@@ -150,6 +154,14 @@ Puppet::Type.newtype(:remote_file) do
     validate do |value|
       if @resource[:proxy] && @resource[:proxy].host != value
         raise 'Conflict between proxy and proxy_host parameters.'
+      end
+
+      if @resource[:proxy] && @resource[:proxy].host != value
+        raise 'Conflict between proxy and proxy_host parameters.'
+      end
+
+      if @resource[:source] =~ /^ftp/
+        raise ArgumentError, "proxy cannot be used with FTP sources"
       end
     end
 


### PR DESCRIPTION
Adds FTP support.

Works like HTTP, including checking timestamps on remote files, except that the `proxy` parameter is disabled.